### PR TITLE
NPE when onPageSelected is called before onMeasure

### DIFF
--- a/material-intro-screen/src/main/java/io/github/dreierf/materialintroscreen/widgets/InkPageIndicator.java
+++ b/material-intro-screen/src/main/java/io/github/dreierf/materialintroscreen/widgets/InkPageIndicator.java
@@ -480,8 +480,10 @@ public class InkPageIndicator extends View implements CustomViewPager.OnPageChan
             }
         }
 
-        moveAnimation = createMoveSelectedAnimator(dotCenterX[now], previousPage, now, steps);
-        moveAnimation.start();
+        if (dotCenterX != null) {
+            moveAnimation = createMoveSelectedAnimator(dotCenterX[now], previousPage, now, steps);
+            moveAnimation.start();
+        }
     }
 
     private ValueAnimator createMoveSelectedAnimator(


### PR DESCRIPTION
Then dotCenterX is not yet initialized, i.e. null. This scenario can happen during Activity restore